### PR TITLE
feat!: Support no_std environments fully in apdu-core crate

### DIFF
--- a/apdu-core/src/command.rs
+++ b/apdu-core/src/command.rs
@@ -1,17 +1,14 @@
-use alloc::vec;
-use alloc::vec::Vec;
-
 /// An APDU command to be transmitted
-pub struct Command {
+pub struct Command<'a> {
     pub cla: u8,
     pub ins: u8,
     pub p1: u8,
     pub p2: u8,
     pub le: Option<u16>,
-    pub payload: Option<Vec<u8>>,
+    pub payload: Option<&'a [u8]>,
 }
 
-impl Command {
+impl<'a> Command<'a> {
     /// Constructs an command with CLA, INS, P1, and P2.
     /// No payloads will be transmitted or received.
     pub fn new(cla: u8, ins: u8, p1: u8, p2: u8) -> Self {
@@ -40,7 +37,7 @@ impl Command {
 
     /// Constructs an command with CLA, INS, P1, P2, and a payload.
     /// No payload will be received.
-    pub fn new_with_payload(cla: u8, ins: u8, p1: u8, p2: u8, payload: Vec<u8>) -> Self {
+    pub fn new_with_payload(cla: u8, ins: u8, p1: u8, p2: u8, payload: &'a [u8]) -> Self {
         Self {
             cla,
             ins,
@@ -59,7 +56,7 @@ impl Command {
         p1: u8,
         p2: u8,
         le: u16,
-        payload: Vec<u8>,
+        payload: &'a [u8],
     ) -> Self {
         Self {
             cla,
@@ -70,11 +67,9 @@ impl Command {
             payload: Some(payload),
         }
     }
-}
 
-impl From<Command> for Vec<u8> {
-    /// Converts the command into octets.
-    fn from(command: Command) -> Self {
+    /// Writes a serialised byte stream onto the mutable buffer.
+    pub fn write(&self, buf: &mut [u8]) {
         let Command {
             cla,
             ins,
@@ -82,36 +77,122 @@ impl From<Command> for Vec<u8> {
             p2,
             le,
             payload,
-        } = command;
+        } = self;
 
-        let mut buffer: Vec<u8> = vec![cla, ins, p1, p2];
+        // &mut [u8] does not have push or extend methods,
+        // So we are using a mutator to have a reference of the buffer and a cursor on them.
+        struct Mutator<'a> {
+            buf: &'a mut [u8],
+            i: usize,
+        }
+
+        impl<'a> Mutator<'a> {
+            fn push(&mut self, b: u8) {
+                self.buf[self.i] = b;
+                self.i += 1;
+            }
+
+            fn extend(&mut self, b: &[u8]) {
+                let len = b.len();
+                self.buf[self.i..self.i + len].copy_from_slice(b);
+                self.i += len;
+            }
+        }
+
+        let mut m = Mutator { buf, i: 0 };
+        m.extend(&[*cla, *ins, *p1, *p2]);
+
         let has_payload = &payload.is_some();
-        if let Some(mut p) = payload {
+        if let Some(p) = payload {
             // According to spec, length can be 0, 1 or 2 bytes
             // 2 bytes is prefaced by 00 to differentiate between 1 byte lengths
             if cfg!(feature = "longer_payloads") && p.len() > u8::MAX as usize {
-                buffer.push(0u8);
-                buffer.push(p.len() as u8);
-                buffer.push((p.len() >> 8) as u8);
-                buffer.append(&mut p);
+                m.push(0u8);
+                m.push(p.len() as u8);
+                m.push((p.len() >> 8) as u8);
             } else {
-                buffer.push(p.len() as u8);
-                buffer.append(&mut p);
+                m.push(p.len() as u8);
             }
+
+            m.extend(p);
         }
 
-        if let Some(l) = le {
+        if let Some(l) = *le {
             if cfg!(feature = "longer_payloads") && l > u8::MAX.into() {
                 if !has_payload {
-                    buffer.push(0u8);
+                    m.push(0u8);
                 }
-                buffer.push(l as u8);
-                buffer.push((l >> 8) as u8);
+                m.push(l as u8);
+                m.push((l >> 8) as u8);
             } else {
-                buffer.push(l as u8);
+                m.push(l as u8);
             }
         }
+    }
 
-        buffer
+    /// Calculates the length of entire the command.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        let (lc, payload) = match self.payload {
+            Some(p) => (
+                match cfg!(feature = "longer_payloads") && p.len() > u8::MAX as usize {
+                    true => 2,
+                    _ => 1,
+                },
+                p.len(),
+            ),
+            _ => (0, 0),
+        };
+
+        let le = match self.le {
+            Some(l) => match cfg!(feature = "longer_payloads") && l > u8::MAX.into() {
+                true => match self.payload.is_some() {
+                    true => 2,
+                    _ => 3,
+                },
+                _ => 1,
+            },
+            _ => 0,
+        };
+
+        // Header is always 4 bytes
+        4 + lc + payload + le
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> From<Command<'a>> for Vec<u8> {
+    /// Converts the command into octets.
+    fn from(command: Command) -> Self {
+        let len = command.len();
+        let mut buf = Vec::with_capacity(len);
+
+        unsafe {
+            buf.set_len(len);
+        }
+
+        command.write(&mut buf);
+
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_to_vec() {
+        assert_eq!(
+            vec![0x01, 0x02, 0x03, 0x04, 0x03, 0x05, 0x06, 0x07, 0x08],
+            Vec::from(Command::new_with_payload_le(
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x08,
+                &[0x05, 0x06, 0x07]
+            )),
+        );
     }
 }

--- a/apdu-core/src/command.rs
+++ b/apdu-core/src/command.rs
@@ -167,6 +167,7 @@ impl<'a> From<Command<'a>> for Vec<u8> {
         let len = command.len();
         let mut buf = Vec::with_capacity(len);
 
+        #[allow(clippy::uninit_vec)]
         unsafe {
             buf.set_len(len);
         }

--- a/apdu-core/src/error.rs
+++ b/apdu-core/src/error.rs
@@ -4,11 +4,11 @@ use crate::Response;
 
 /// An error that was returned from the card or reader
 #[derive(Debug)]
-pub struct Error {
-    pub response: Response,
+pub struct Error<'a> {
+    pub response: Response<'a>,
 }
 
-impl Display for Error {
+impl<'a> Display for Error<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let (sw1, sw2) = self.response.trailer;
 
@@ -21,4 +21,4 @@ impl Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl<'a> std::error::Error for Error<'a> {}

--- a/apdu-core/src/lib.rs
+++ b/apdu-core/src/lib.rs
@@ -55,21 +55,21 @@ impl std::error::Error for HandleError {}
 pub trait HandlerInCtx<Ctx = ()> {
     /// Handles the APDU command in a specific context.
     /// Implementations must transmit the command to the card through a reader,
-    /// then receive the response from them.
+    /// then receive the response from them, returning length of the data written.
     fn handle_in_ctx(
         &self,
         ctx: Ctx,
         command: &[u8],
         response: &mut [u8],
-    ) -> Result<(), HandleError>;
+    ) -> Result<usize, HandleError>;
 }
 
 /// An handler to handle an APDU command and receive a response
 pub trait Handler: HandlerInCtx<()> {
     /// Handles the APDU command.
     /// Implementations must transmit the command to the card through a reader,
-    /// then receive the response from them.
-    fn handle(&self, command: &[u8], response: &mut [u8]) -> Result<(), HandleError> {
+    /// then receive the response from them, returning length of the data written.
+    fn handle(&self, command: &[u8], response: &mut [u8]) -> Result<usize, HandleError> {
         self.handle_in_ctx((), command, response)
     }
 }

--- a/apdu-core/src/lib.rs
+++ b/apdu-core/src/lib.rs
@@ -51,17 +51,14 @@ impl Display for HandleError {
 #[cfg(feature = "std")]
 impl std::error::Error for HandleError {}
 
+pub type Result = std::result::Result<usize, HandleError>;
+
 /// An handler to handle an APDU command and receive a response in a specific context.
 pub trait HandlerInCtx<Ctx = ()> {
     /// Handles the APDU command in a specific context.
     /// Implementations must transmit the command to the card through a reader,
     /// then receive the response from them, returning length of the data written.
-    fn handle_in_ctx(
-        &self,
-        ctx: Ctx,
-        command: &[u8],
-        response: &mut [u8],
-    ) -> Result<usize, HandleError>;
+    fn handle_in_ctx(&self, ctx: Ctx, command: &[u8], response: &mut [u8]) -> Result;
 }
 
 /// An handler to handle an APDU command and receive a response
@@ -69,7 +66,7 @@ pub trait Handler: HandlerInCtx<()> {
     /// Handles the APDU command.
     /// Implementations must transmit the command to the card through a reader,
     /// then receive the response from them, returning length of the data written.
-    fn handle(&self, command: &[u8], response: &mut [u8]) -> Result<usize, HandleError> {
+    fn handle(&self, command: &[u8], response: &mut [u8]) -> Result {
         self.handle_in_ctx((), command, response)
     }
 }

--- a/apdu-core/src/lib.rs
+++ b/apdu-core/src/lib.rs
@@ -2,8 +2,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 mod command;
 mod error;
 mod response;
@@ -12,12 +10,58 @@ pub use command::*;
 pub use error::*;
 pub use response::*;
 
+use core::fmt::{Debug, Display, Formatter};
+
+pub enum HandleError {
+    /// The buffer is too small to write the response.
+    /// Reallocate with the capacity and retry.
+    NotEnoughBuffer(usize),
+
+    /// Failed to communicate through physical NFC layer.
+    /// Hardware or OS API error?
+    Nfc(Box<dyn Display>),
+}
+
+impl HandleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use HandleError::*;
+        match self {
+            NotEnoughBuffer(size) => write!(
+                f,
+                "The buffer is too small to write the response. (needs {} bytes)",
+                size,
+            ),
+            Nfc(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Debug for HandleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Self::fmt(self, f)
+    }
+}
+
+impl Display for HandleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Self::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HandleError {}
+
 /// An handler to handle an APDU command and receive a response in a specific context.
 pub trait HandlerInCtx<Ctx = ()> {
     /// Handles the APDU command in a specific context.
     /// Implementations must transmit the command to the card through a reader,
     /// then receive the response from them.
-    fn handle_in_ctx(&self, ctx: Ctx, command: Command) -> Response;
+    fn handle_in_ctx(
+        &self,
+        ctx: Ctx,
+        command: &[u8],
+        response: &mut [u8],
+    ) -> Result<(), HandleError>;
 }
 
 /// An handler to handle an APDU command and receive a response
@@ -25,7 +69,7 @@ pub trait Handler: HandlerInCtx<()> {
     /// Handles the APDU command.
     /// Implementations must transmit the command to the card through a reader,
     /// then receive the response from them.
-    fn handle(&self, command: Command) -> Response {
-        self.handle_in_ctx((), command)
+    fn handle(&self, command: &[u8], response: &mut [u8]) -> Result<(), HandleError> {
+        self.handle_in_ctx((), command, response)
     }
 }

--- a/apdu-core/src/response.rs
+++ b/apdu-core/src/response.rs
@@ -19,6 +19,7 @@ impl Response {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Vec<u8>> for Response {
     fn from(mut bytes: Vec<u8>) -> Self {
         let sw2 = bytes.pop();
@@ -34,6 +35,7 @@ impl From<Vec<u8>> for Response {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Response> for Result<Vec<u8>, Error> {
     /// Converts the response to a result of octets.
     fn from(response: Response) -> Self {

--- a/apdu/src/command.rs
+++ b/apdu/src/command.rs
@@ -9,7 +9,7 @@ const INS_VERIFY: u8 = 0x20;
 
 macro_rules! impl_into_vec {
     ($name: ty) => {
-        impl From<$name> for Vec<u8> {
+        impl<'a> From<$name> for Vec<u8> {
             fn from(cmd: $name) -> Self {
                 crate::Command::from(cmd).into()
             }
@@ -18,21 +18,21 @@ macro_rules! impl_into_vec {
 }
 
 /// `SELECT FILE` (0xA4) command.
-pub struct SelectFileCommand {
+pub struct SelectFileCommand<'a> {
     p1: u8,
     p2: u8,
-    payload: Vec<u8>,
+    payload: &'a [u8],
 }
 
-impl SelectFileCommand {
+impl<'a> SelectFileCommand<'a> {
     /// Constructs a `SELECT FILE` command.
-    pub fn new(p1: u8, p2: u8, payload: Vec<u8>) -> Self {
+    pub fn new(p1: u8, p2: u8, payload: &'a [u8]) -> Self {
         Self { p1, p2, payload }
     }
 }
 
-impl From<SelectFileCommand> for crate::Command {
-    fn from(cmd: SelectFileCommand) -> Self {
+impl<'a> From<SelectFileCommand<'a>> for crate::Command<'a> {
+    fn from(cmd: SelectFileCommand<'a>) -> Self {
         match cmd.payload.len() {
             0 => Self::new(CLA_DEFAULT, INS_SELECT_FILE, cmd.p1, cmd.p2),
             _ => Self::new_with_payload(CLA_DEFAULT, INS_SELECT_FILE, cmd.p1, cmd.p2, cmd.payload),
@@ -40,10 +40,10 @@ impl From<SelectFileCommand> for crate::Command {
     }
 }
 
-impl_into_vec!(SelectFileCommand);
+impl_into_vec!(SelectFileCommand<'a>);
 
 /// Constructs a `SELECT FILE` command.
-pub fn select_file(p1: u8, p2: u8, payload: Vec<u8>) -> SelectFileCommand {
+pub fn select_file(p1: u8, p2: u8, payload: &[u8]) -> SelectFileCommand {
     SelectFileCommand::new(p1, p2, payload)
 }
 
@@ -61,7 +61,7 @@ impl ReadBinaryCommand {
     }
 }
 
-impl From<ReadBinaryCommand> for crate::Command {
+impl<'a> From<ReadBinaryCommand> for crate::Command<'a> {
     fn from(cmd: ReadBinaryCommand) -> Self {
         Self::new_with_le(CLA_DEFAULT, INS_READ_BINARY, cmd.p1, cmd.p2, cmd.le.into())
     }
@@ -75,20 +75,20 @@ pub fn read_binary(p1: u8, p2: u8, le: u8) -> ReadBinaryCommand {
 }
 
 /// `VERIFY` (0x20) command.
-pub struct VerifyCommand {
+pub struct VerifyCommand<'a> {
     p2: u8,
-    payload: Vec<u8>,
+    payload: &'a [u8],
 }
 
-impl VerifyCommand {
+impl<'a> VerifyCommand<'a> {
     /// Constructs a `VERIFY` command.
-    pub fn new(p2: u8, payload: Vec<u8>) -> Self {
+    pub fn new(p2: u8, payload: &'a [u8]) -> Self {
         Self { p2, payload }
     }
 }
 
-impl From<VerifyCommand> for crate::Command {
-    fn from(cmd: VerifyCommand) -> Self {
+impl<'a> From<VerifyCommand<'a>> for crate::Command<'a> {
+    fn from(cmd: VerifyCommand<'a>) -> Self {
         match cmd.payload.len() {
             0 => Self::new(CLA_DEFAULT, INS_VERIFY, 0x00, cmd.p2),
             _ => Self::new_with_payload(CLA_DEFAULT, INS_VERIFY, 0x00, cmd.p2, cmd.payload),
@@ -96,9 +96,9 @@ impl From<VerifyCommand> for crate::Command {
     }
 }
 
-impl_into_vec!(VerifyCommand);
+impl_into_vec!(VerifyCommand<'a>);
 
 /// Constructs a `VERIFY` command.
-pub fn verify(p2: u8, payload: Vec<u8>) -> VerifyCommand {
+pub fn verify(p2: u8, payload: &[u8]) -> VerifyCommand {
     VerifyCommand::new(p2, payload)
 }

--- a/apdu/src/lib.rs
+++ b/apdu/src/lib.rs
@@ -94,9 +94,9 @@ pub use crate::error::Error;
 #[cfg(test)]
 mod tests {
     #[derive(Debug, PartialEq, Eq, crate::Response)]
-    enum Response {
+    enum Response<'a> {
         #[apdu(0x90, 0x00)]
-        Ok(Vec<u8>),
+        Ok(&'a [u8]),
 
         #[apdu(0x63, 0xC0..=0xCF)]
         VerifyFailed(
@@ -115,10 +115,10 @@ mod tests {
     #[test]
     fn test_success() {
         let bytes: Vec<u8> = vec![0x12, 0x34, 0x56, 0x90, 0x00];
-        let response = Response::from(bytes.clone());
+        let response = Response::from(bytes.as_slice());
 
         if let Response::Ok(payload) = response {
-            assert_eq!(&bytes[..3], &payload)
+            assert_eq!(&bytes[..3], payload)
         } else {
             panic!("Response is not Ok variant")
         }
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn test_not_ok() {
         let bytes: Vec<u8> = vec![0x69, 0x12];
-        let response = Response::from(bytes.clone());
+        let response = Response::from(bytes.as_slice());
 
         assert_eq!(Response::NotOk, response)
     }
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn test_unknown() {
         let bytes: Vec<u8> = vec![0x70, 0x00];
-        let response = Response::from(bytes.clone());
+        let response = Response::from(bytes.as_slice());
 
         if let Response::Unknown(sw1, sw2) = response {
             assert_eq!((0x70, 0x00), (sw1, sw2))
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn test_inject() {
         let bytes: Vec<u8> = vec![0x63, 0xC7];
-        let response = Response::from(bytes.clone());
+        let response = Response::from(bytes.as_slice());
 
         if let Response::VerifyFailed(count) = response {
             assert_eq!(7, count)

--- a/apdu/src/lib.rs
+++ b/apdu/src/lib.rs
@@ -5,7 +5,7 @@
 //! [apdu-core](https://docs.rs/apdu-core/) crate declares types for APDU command and response in low-level.
 //! It is fully cross-platform since this crate contains only type declarations.
 //! ```rust
-//! let command = apdu_core::Command::new_with_payload(0x00, 0xA4, 0x12, 0x34, vec![0x56, 0x78]);
+//! let command = apdu_core::Command::new_with_payload(0x00, 0xA4, 0x12, 0x34, &[0x56, 0x78]);
 //! let bytes: Vec<u8> = command.into();
 //!
 //! assert_eq!(
@@ -22,7 +22,7 @@
 //! This apdu crate declares some high-level APIs to compose APDU commands or parse their responses easily.
 //! It is cross-platform now, but some os-specific features can be added in the future.
 //! ```rust
-//! let command = apdu::command::select_file(0x12, 0x34, vec![0x56, 0x78]);
+//! let command = apdu::command::select_file(0x12, 0x34, &[0x56, 0x78]);
 //! let bytes: Vec<u8> = command.into();
 //!
 //! assert_eq!(vec![0x00, 0xA4, 0x12, 0x34, 0x02, 0x56, 0x78], bytes);
@@ -41,14 +41,14 @@
 //! }
 //!
 //! /// Now implement `From<YourType>` for `apdu_core::Command`:
-//! impl From<DoSomethingCommand> for apdu_core::Command {
+//! impl<'a> From<DoSomethingCommand> for apdu_core::Command<'a> {
 //!     fn from(cmd: DoSomethingCommand) -> Self {
 //!         Self::new(0x12, 0x34, 0x56, 0x78)
 //!     }
 //! }
 //!
 //! /// ... then dependents of your library can be used with other crate that has an APDU implementation:
-//! fn handle_apdu_command(cmd: impl Into<apdu_core::Command>) {
+//! fn handle_apdu_command<'a>(cmd: impl Into<apdu_core::Command<'a>>) {
 //!     // connect to your card ...
 //!     // transmit the command ...
 //!     // ... and wait for the response
@@ -61,12 +61,13 @@
 //! struct NfcReader;
 //!
 //! impl apdu_core::HandlerInCtx<()> for NfcReader {
-//!     fn handle_in_ctx(&self, _ctx: (), cmd: apdu_core::Command) -> apdu_core::Response {
+//!     fn handle_in_ctx(&self, _ctx: (), command: &[u8], response: &mut [u8]) -> apdu_core::Result {
 //!         // connect to your card ...
 //!         // transmit the command ...
 //!         // ... and wait for the response
+//! #       let len = 0;
 //!
-//!         vec![].into()
+//!         Ok(len) // return the length of response
 //!     }
 //! }
 //! ```


### PR DESCRIPTION
Closes #10 

apdu-rs was written on top of `Vec<u8>` buffers, but that is not compatible for `no_std` environments, without `alloc` feature. As described in #10, this compatibility is now an important objective. We are migrating `Vec<u8>` to `&mut [u8]`, leaving support of converting to `Vec<u8>`.

To handler implementors: now handlers need to write onto the mutable buffer instead of returning a `Vec<u8>`. Handlers must return the length of data actually written on success, or `HandleError::NotEnoughBuffer` otherwise.